### PR TITLE
Fix codex one-shot mode search flag

### DIFF
--- a/config/agents.yaml
+++ b/config/agents.yaml
@@ -28,7 +28,6 @@ agents:
     #   - --config
     #   - sandbox_workspace_write.network_access=true
     #   - --search
-    #   - "YOUR PROMPT HERE"
     command:
       - codex
       - exec


### PR DESCRIPTION
Fixing codex one shot command order
Adding commented out for properly handling web search

---
Automated changes via Slack thread 1764858974.068079 in channel C0A0XB5KYQJ.