### PR TITLE
Add better context management

### DIFF
--- a/src/core/context_builder.py
+++ b/src/core/context_builder.py
@@ -1,0 +1,124 @@
+"""Build context strings for agents based on conversation history."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.core.models import ConversationInteraction
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ContextBuilder:
+    """Builds formatted context strings for agent task inclusion."""
+
+    @staticmethod
+    def build_context_for_agent(
+        interactions: list[ConversationInteraction],
+        summary: str | None = None,
+        summarized_count: int = 0
+    ) -> str:
+        """
+        Build the context section to prepend to agent task.
+
+        If there's a summary and summarized_count > 0, includes the summary
+        plus the most recent interactions in detail. Otherwise, shows all
+        interactions chronologically.
+
+        Args:
+            interactions: List of ConversationInteraction objects
+            summary: Optional summary of early interactions
+            summarized_count: How many interactions were summarized (0 if no summary)
+
+        Returns:
+            Formatted context string ready to include in task_text
+        """
+        if not interactions:
+            return ""
+
+        if summary and summarized_count > 0:
+            return ContextBuilder._build_with_summary(
+                interactions, summary, summarized_count
+            )
+        else:
+            return ContextBuilder._build_without_summary(interactions)
+
+    @staticmethod
+    def _build_without_summary(interactions: list[ConversationInteraction]) -> str:
+        """
+        Build context when there's no summary (< 10 interactions).
+
+        Shows all interactions chronologically.
+
+        Args:
+            interactions: List of interactions to format
+
+        Returns:
+            Formatted context string
+        """
+        lines = []
+        for interaction in interactions:
+            user_text = interaction.user_message.content
+            agent_text = interaction.agent_message.content
+
+            lines.append("USER:")
+            lines.append(user_text)
+            lines.append("AGENT:")
+            lines.append(agent_text)
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _build_with_summary(
+        interactions: list[ConversationInteraction],
+        summary: str,
+        summarized_count: int
+    ) -> str:
+        """
+        Build context when there's a summary.
+
+        Shows summary section, then recent interactions in detail.
+
+        Args:
+            interactions: Full list of interactions
+            summary: Summary text of early interactions
+            summarized_count: How many interactions were summarized
+
+        Returns:
+            Formatted context string with summary and recent interactions
+        """
+        lines = []
+
+        # Add summary section
+        lines.append("### SUMMARY BEFORE THESE MESSAGES")
+        lines.append(summary)
+        lines.append("")
+        lines.append("### MORE RECENT MESSAGES")
+
+        # Show interactions after the summarized ones
+        for interaction in interactions[summarized_count:]:
+            user_text = interaction.user_message.content
+            agent_text = interaction.agent_message.content
+
+            lines.append("USER:")
+            lines.append(user_text)
+            lines.append("AGENT:")
+            lines.append(agent_text)
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def format_interaction_pair(user_msg: str, agent_msg: str) -> str:
+        """
+        Format a single interaction pair for context.
+
+        Args:
+            user_msg: User message text
+            agent_msg: Agent response text
+
+        Returns:
+            Formatted interaction pair
+        """
+        return f"USER:\n{user_msg}\nAGENT:\n{agent_msg}"

--- a/src/core/conversation_summarizer.py
+++ b/src/core/conversation_summarizer.py
@@ -1,0 +1,144 @@
+"""Generate summaries of conversation interactions."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.core.models import ConversationInteraction
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ConversationSummarizer:
+    """Generates concise summaries of conversation interactions."""
+
+    @staticmethod
+    def summarize_interactions(
+        interactions: list[ConversationInteraction],
+        count: int = 5
+    ) -> str:
+        """
+        Summarize first N interactions into a concise summary.
+
+        The summary includes:
+        - Key numbers, names, specific requirements mentioned
+        - Major decisions made
+        - Problems solved
+        - Components/features added/modified
+
+        Emphasis is placed on specific details the user mentioned.
+
+        Args:
+            interactions: List of ConversationInteraction objects
+            count: How many interactions to summarize (default 5)
+
+        Returns:
+            A concise summary string of the interactions
+        """
+        if not interactions:
+            return ""
+
+        # Take only the first N interactions
+        to_summarize = interactions[:min(count, len(interactions))]
+
+        # Extract key information
+        summary_parts = []
+
+        for interaction in to_summarize:
+            user_msg = interaction.user_message.content
+            agent_msg = interaction.agent_message.content
+
+            # Extract specific details from user message
+            user_details = ConversationSummarizer._extract_details(user_msg)
+
+            # Extract what agent accomplished from agent message
+            agent_actions = ConversationSummarizer._extract_actions(agent_msg)
+
+            # Combine into summary line if both exist
+            if user_details and agent_actions:
+                summary_parts.append(
+                    f"{user_details}: {agent_actions}"
+                )
+            elif user_details:
+                summary_parts.append(user_details)
+            elif agent_actions:
+                summary_parts.append(agent_actions)
+
+        # Join parts into a flowing summary
+        if not summary_parts:
+            return "Conversation about code modifications."
+
+        # Combine parts with period separation, then refine
+        raw_summary = ". ".join(summary_parts)
+        if not raw_summary.endswith("."):
+            raw_summary += "."
+
+        return raw_summary
+
+    @staticmethod
+    def _extract_details(text: str) -> str:
+        """
+        Extract specific details (numbers, names, requirements) from text.
+
+        Args:
+            text: The input text to extract from
+
+        Returns:
+            A short phrase with key details
+        """
+        if not text:
+            return ""
+
+        # Look for patterns like "52 cards", "2 Jokers", component names, etc.
+        # Keep the first sentence or two that contains actionable info
+        sentences = re.split(r'[.!?]+', text)
+        key_sentence = sentences[0].strip() if sentences else ""
+
+        # Limit to reasonable length
+        if len(key_sentence) > 150:
+            key_sentence = key_sentence[:150].rsplit(' ', 1)[0] + "..."
+
+        return key_sentence
+
+    @staticmethod
+    def _extract_actions(text: str) -> str:
+        """
+        Extract what the agent actually did from their response.
+
+        Args:
+            text: The agent's response text
+
+        Returns:
+            A short phrase describing the action taken
+        """
+        if not text:
+            return ""
+
+        # Look for action verbs in agent responses
+        action_patterns = [
+            r"(added|created|implemented|added).*?(?:[.!?]|$)",
+            r"(updated|modified|changed).*?(?:[.!?]|$)",
+            r"(fixed|resolved|corrected).*?(?:[.!?]|$)",
+            r"(removed|deleted).*?(?:[.!?]|$)",
+        ]
+
+        for pattern in action_patterns:
+            match = re.search(pattern, text, re.IGNORECASE)
+            if match:
+                action = match.group(0).strip()
+                # Keep it concise
+                if len(action) > 120:
+                    action = action[:120].rsplit(' ', 1)[0] + "..."
+                return action
+
+        # Fallback: first sentence
+        sentences = re.split(r'[.!?]+', text)
+        first = sentences[0].strip() if sentences else ""
+
+        if len(first) > 120:
+            first = first[:120].rsplit(' ', 1)[0] + "..."
+
+        return first

--- a/src/core/interaction_classifier.py
+++ b/src/core/interaction_classifier.py
@@ -1,0 +1,65 @@
+"""Classify agent responses to determine what goes into conversation history."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.agent_adapters.base import AgentResult
+
+LOGGER = logging.getLogger(__name__)
+
+
+class InteractionClassifier:
+    """Classifies agent results to determine substantive work."""
+
+    @staticmethod
+    def is_substantive(result: AgentResult) -> bool:
+        """
+        Returns True if the agent result represents substantive work.
+
+        A result is substantive if:
+        1. Agent made file edits (len(result.file_edits) > 0), OR
+        2. Agent reported success (result.success == True), OR
+        3. Agent returned meaningful text content (not empty/whitespace)
+
+        Uses structured output fields rather than pattern matching on text.
+        This avoids brittleness when agents change their messaging.
+
+        Args:
+            result: The AgentResult from an agent adapter
+
+        Returns:
+            True if the result should be included in conversation history
+        """
+        # File edits are definitive proof of work
+        if result.file_edits:
+            return True
+
+        # Success flag indicates meaningful work was done
+        if result.success and result.output_text.strip():
+            return True
+
+        # Any meaningful text content counts as substantive
+        # (even if not explicitly marked as success)
+        if result.output_text.strip():
+            return True
+
+        return False
+
+    @staticmethod
+    def extract_context_content(result: AgentResult) -> str:
+        """
+        Extract the main content for conversation history.
+
+        Returns the substantive text from result.output_text, which is
+        the agent's description of what was done.
+
+        Args:
+            result: The AgentResult from an agent adapter
+
+        Returns:
+            The output text to include in conversation history
+        """
+        return result.output_text

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -61,6 +61,16 @@ class ConversationMessage:
 
 
 @dataclass
+class ConversationInteraction:
+    """Represents a user-agent interaction pair with summary tracking."""
+    interaction_number: int  # 1-indexed
+    user_message: ConversationMessage
+    agent_message: ConversationMessage
+    is_summarized: bool = False  # True if this interaction is part of summary
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass
 class Session:
     project_id: str
     channel_id: str
@@ -70,6 +80,9 @@ class Session:
     project_path: Path
     active_model: Optional[str] = None  # User-facing model name (e.g., "sonnet", "base", "pro")
     conversation_history: List[ConversationMessage] = field(default_factory=list)
+    interactions: List[ConversationInteraction] = field(default_factory=list)  # Substantive interaction pairs
+    conversation_summary: Optional[str] = None  # Cached summary of early interactions
+    summary_interaction_count: int = 0  # How many interactions were summarized
     session_context: Dict[str, Any] = field(default_factory=dict)
     status: SessionStatus = SessionStatus.ACTIVE
     id: UUID = field(default_factory=uuid4)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Remote Coder."""

--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -1,0 +1,165 @@
+"""Tests for ContextBuilder."""
+
+import pytest
+
+from src.core.context_builder import ContextBuilder
+from src.core.models import ConversationInteraction, ConversationMessage
+
+
+class TestContextBuilder:
+    """Test cases for ContextBuilder."""
+
+    def test_build_context_empty_interactions(self):
+        """Building context with no interactions should return empty string."""
+        context = ContextBuilder.build_context_for_agent([])
+        assert context == ""
+
+    def test_build_context_without_summary_single(self):
+        """Build context without summary should show interaction."""
+        interaction = ConversationInteraction(
+            interaction_number=1,
+            user_message=ConversationMessage(role="user", content="Add a CardList"),
+            agent_message=ConversationMessage(role="assistant", content="Added CardList component"),
+        )
+
+        context = ContextBuilder.build_context_for_agent([interaction])
+
+        assert "USER:" in context
+        assert "AGENT:" in context
+        assert "Add a CardList" in context
+        assert "Added CardList" in context
+        assert "SUMMARY" not in context
+
+    def test_build_context_without_summary_multiple(self):
+        """Build context without summary should show all interactions."""
+        interactions = [
+            ConversationInteraction(
+                interaction_number=1,
+                user_message=ConversationMessage(role="user", content="Request 1"),
+                agent_message=ConversationMessage(role="assistant", content="Response 1"),
+            ),
+            ConversationInteraction(
+                interaction_number=2,
+                user_message=ConversationMessage(role="user", content="Request 2"),
+                agent_message=ConversationMessage(role="assistant", content="Response 2"),
+            ),
+        ]
+
+        context = ContextBuilder.build_context_for_agent(interactions)
+
+        # Should have all messages
+        assert context.count("USER:") == 2
+        assert context.count("AGENT:") == 2
+        assert "Request 1" in context
+        assert "Request 2" in context
+
+    def test_build_context_with_summary(self):
+        """Build context with summary should include summary section."""
+        interactions = [
+            ConversationInteraction(
+                interaction_number=i + 1,
+                user_message=ConversationMessage(role="user", content=f"Request {i+1}"),
+                agent_message=ConversationMessage(role="assistant", content=f"Response {i+1}"),
+            )
+            for i in range(10)
+        ]
+
+        summary = "Built CardList with 52 cards, then added 2 Jokers for total 54."
+
+        context = ContextBuilder.build_context_for_agent(
+            interactions,
+            summary=summary,
+            summarized_count=5
+        )
+
+        # Should have summary section
+        assert "SUMMARY BEFORE THESE MESSAGES" in context
+        assert "MORE RECENT MESSAGES" in context
+        assert summary in context
+
+        # Should have recent interactions (6-10)
+        assert "Request 6" in context
+        assert "Response 6" in context
+        assert "Request 10" in context
+        assert "Response 10" in context
+
+        # Should NOT have early interactions (1-5) as individual interactions
+        # (they're in the summary instead)
+        assert "Request 1" not in context
+        assert context.count("Request") == 5  # Only requests 6-10
+
+    def test_format_interaction_pair(self):
+        """Format a single interaction pair correctly."""
+        formatted = ContextBuilder.format_interaction_pair(
+            "Add CardList",
+            "Added CardList component"
+        )
+
+        assert "USER:" in formatted
+        assert "AGENT:" in formatted
+        assert "Add CardList" in formatted
+        assert "Added CardList component" in formatted
+        assert formatted.count("\n") >= 2
+
+    def test_build_context_preserves_interaction_order(self):
+        """Interactions should be in chronological order."""
+        interactions = [
+            ConversationInteraction(
+                interaction_number=1,
+                user_message=ConversationMessage(role="user", content="First"),
+                agent_message=ConversationMessage(role="assistant", content="First response"),
+            ),
+            ConversationInteraction(
+                interaction_number=2,
+                user_message=ConversationMessage(role="user", content="Second"),
+                agent_message=ConversationMessage(role="assistant", content="Second response"),
+            ),
+        ]
+
+        context = ContextBuilder.build_context_for_agent(interactions)
+
+        # "First" should come before "Second"
+        assert context.index("First") < context.index("Second")
+
+    def test_build_context_with_summary_and_many_interactions(self):
+        """With summary and 10 interactions, should show summary + recent 5."""
+        interactions = [
+            ConversationInteraction(
+                interaction_number=i + 1,
+                user_message=ConversationMessage(role="user", content=f"Request {i+1}"),
+                agent_message=ConversationMessage(role="assistant", content=f"Response {i+1}"),
+            )
+            for i in range(10)
+        ]
+
+        summary = "Completed 5 rounds of development work."
+
+        context = ContextBuilder.build_context_for_agent(
+            interactions,
+            summary=summary,
+            summarized_count=5
+        )
+
+        # Should have both sections
+        assert "SUMMARY" in context
+        assert "MORE RECENT" in context
+
+        # Count USER: labels - should be 5 (requests 6-10)
+        assert context.count("USER:") == 5
+
+    def test_build_context_without_summary_null_values(self):
+        """Build context with None summary should not include summary section."""
+        interaction = ConversationInteraction(
+            interaction_number=1,
+            user_message=ConversationMessage(role="user", content="Test"),
+            agent_message=ConversationMessage(role="assistant", content="Response"),
+        )
+
+        context = ContextBuilder.build_context_for_agent(
+            [interaction],
+            summary=None,
+            summarized_count=0
+        )
+
+        assert "SUMMARY" not in context
+        assert "USER:" in context

--- a/tests/test_conversation_summarizer.py
+++ b/tests/test_conversation_summarizer.py
@@ -1,0 +1,139 @@
+"""Tests for ConversationSummarizer."""
+
+import pytest
+
+from src.core.conversation_summarizer import ConversationSummarizer
+from src.core.models import ConversationInteraction, ConversationMessage
+
+
+class TestConversationSummarizer:
+    """Test cases for ConversationSummarizer."""
+
+    def test_summarize_empty_interactions(self):
+        """Summarizing empty list should return empty string."""
+        summary = ConversationSummarizer.summarize_interactions([])
+        assert summary == ""
+
+    def test_summarize_single_interaction(self):
+        """Summarizing a single interaction should work."""
+        user_msg = ConversationMessage(role="user", content="Add a CardList component for 52 cards")
+        agent_msg = ConversationMessage(role="assistant", content="Added CardList component, displays all 52 cards")
+
+        interaction = ConversationInteraction(
+            interaction_number=1,
+            user_message=user_msg,
+            agent_message=agent_msg,
+        )
+
+        summary = ConversationSummarizer.summarize_interactions([interaction], count=1)
+
+        assert len(summary) > 0
+        assert "52" in summary or "CardList" in summary or "card" in summary.lower()
+
+    def test_summarize_multiple_interactions(self):
+        """Summarizing multiple interactions should preserve details."""
+        interactions = [
+            ConversationInteraction(
+                interaction_number=1,
+                user_message=ConversationMessage(role="user", content="Add CardList component for 52 cards"),
+                agent_message=ConversationMessage(role="assistant", content="Created CardList, displays 52 cards"),
+            ),
+            ConversationInteraction(
+                interaction_number=2,
+                user_message=ConversationMessage(role="user", content="Include 2 Jokers as well"),
+                agent_message=ConversationMessage(role="assistant", content="Updated CardList to include 2 Jokers, total 54"),
+            ),
+        ]
+
+        summary = ConversationSummarizer.summarize_interactions(interactions, count=2)
+
+        # Should contain key numbers and context
+        assert "52" in summary or "54" in summary or "Card" in summary
+        assert len(summary) > 0
+        assert summary.endswith(".")
+
+    def test_summarize_respects_count_limit(self):
+        """Summarize should only use first N interactions."""
+        interactions = []
+        for i in range(10):
+            interactions.append(
+                ConversationInteraction(
+                    interaction_number=i + 1,
+                    user_message=ConversationMessage(role="user", content=f"Request {i+1}"),
+                    agent_message=ConversationMessage(role="assistant", content=f"Response {i+1}"),
+                )
+            )
+
+        # Only summarize first 5
+        summary = ConversationSummarizer.summarize_interactions(interactions, count=5)
+
+        # Should reference early interactions
+        assert len(summary) > 0
+        # Should end with period
+        assert summary.endswith(".")
+
+    def test_summarize_extracts_numbers(self):
+        """Summarize should preserve specific numbers mentioned."""
+        interactions = [
+            ConversationInteraction(
+                interaction_number=1,
+                user_message=ConversationMessage(role="user", content="Create a component to display 52 playing cards"),
+                agent_message=ConversationMessage(role="assistant", content="Created PlayingCard component with 52 cards"),
+            ),
+        ]
+
+        summary = ConversationSummarizer.summarize_interactions(interactions, count=1)
+
+        # Should preserve the number 52
+        assert "52" in summary
+
+    def test_summarize_with_long_messages(self):
+        """Summarize should handle long messages gracefully."""
+        long_user = "A" * 500
+        long_agent = "B" * 500
+
+        interaction = ConversationInteraction(
+            interaction_number=1,
+            user_message=ConversationMessage(role="user", content=long_user),
+            agent_message=ConversationMessage(role="assistant", content=long_agent),
+        )
+
+        summary = ConversationSummarizer.summarize_interactions([interaction], count=1)
+
+        # Summary should be finite and shorter than original
+        assert len(summary) < len(long_user) + len(long_agent)
+        assert len(summary) > 0
+
+    def test_extract_details(self):
+        """_extract_details should pull key information from text."""
+        text = "Add a CardList component that displays all 52 cards in the deck"
+        details = ConversationSummarizer._extract_details(text)
+
+        assert len(details) > 0
+        assert "CardList" in details or "cards" in details.lower()
+
+    def test_extract_details_empty(self):
+        """_extract_details should handle empty text."""
+        details = ConversationSummarizer._extract_details("")
+        assert details == ""
+
+    def test_extract_actions(self):
+        """_extract_actions should find what agent did."""
+        text = "Added CardList component to display all 52 cards."
+        action = ConversationSummarizer._extract_actions(text)
+
+        assert len(action) > 0
+        assert "added" in action.lower() or "Added" in action
+
+    def test_extract_actions_multiple_patterns(self):
+        """_extract_actions should find various action patterns."""
+        test_cases = [
+            ("fixed the bug in the parser", "fixed"),
+            ("Updated the configuration file", "Updated"),
+            ("Removed the deprecated function", "Removed"),
+            ("Created a new utility module", "Created"),
+        ]
+
+        for text, expected_word in test_cases:
+            action = ConversationSummarizer._extract_actions(text)
+            assert expected_word.lower() in action.lower()

--- a/tests/test_interaction_classifier.py
+++ b/tests/test_interaction_classifier.py
@@ -1,0 +1,100 @@
+"""Tests for InteractionClassifier."""
+
+import pytest
+
+from src.agent_adapters.base import AgentResult, FileEdit
+from src.core.interaction_classifier import InteractionClassifier
+
+
+class TestInteractionClassifier:
+    """Test cases for InteractionClassifier."""
+
+    def test_is_substantive_with_file_edits(self):
+        """File edits alone should mark result as substantive."""
+        result = AgentResult(
+            success=True,
+            output_text="Made some changes",
+            file_edits=[FileEdit(path="file.py", type="edit")],
+        )
+        assert InteractionClassifier.is_substantive(result) is True
+
+    def test_is_substantive_with_success_and_text(self):
+        """Success with non-empty text should be substantive."""
+        result = AgentResult(
+            success=True,
+            output_text="I added a new function to calculate totals.",
+        )
+        assert InteractionClassifier.is_substantive(result) is True
+
+    def test_is_substantive_with_text_only(self):
+        """Non-empty text alone should be substantive."""
+        result = AgentResult(
+            success=False,
+            output_text="I found an issue with the code.",
+        )
+        assert InteractionClassifier.is_substantive(result) is True
+
+    def test_is_not_substantive_empty_text_and_no_edits(self):
+        """Empty text with no edits should not be substantive."""
+        result = AgentResult(
+            success=False,
+            output_text="",
+        )
+        assert InteractionClassifier.is_substantive(result) is False
+
+    def test_is_not_substantive_whitespace_only(self):
+        """Whitespace-only text should not be substantive."""
+        result = AgentResult(
+            success=False,
+            output_text="   \n  \t  ",
+        )
+        assert InteractionClassifier.is_substantive(result) is False
+
+    def test_is_substantive_with_file_edits_no_text(self):
+        """File edits without text should still be substantive."""
+        result = AgentResult(
+            success=False,
+            output_text="",
+            file_edits=[FileEdit(path="test.py", type="create")],
+        )
+        assert InteractionClassifier.is_substantive(result) is True
+
+    def test_extract_context_content(self):
+        """Extract content should return the output_text."""
+        result = AgentResult(
+            success=True,
+            output_text="I implemented the CardList component.",
+            file_edits=[FileEdit(path="components.py", type="edit")],
+        )
+        content = InteractionClassifier.extract_context_content(result)
+        assert content == "I implemented the CardList component."
+
+    def test_extract_context_content_empty(self):
+        """Extract content should return empty string if output_text is empty."""
+        result = AgentResult(
+            success=False,
+            output_text="",
+        )
+        content = InteractionClassifier.extract_context_content(result)
+        assert content == ""
+
+    def test_is_substantive_success_with_empty_text(self):
+        """Success with empty text should not be substantive."""
+        result = AgentResult(
+            success=True,
+            output_text="",
+        )
+        assert InteractionClassifier.is_substantive(result) is False
+
+    def test_is_substantive_multiple_file_edits(self):
+        """Multiple file edits should be substantive."""
+        result = AgentResult(
+            success=False,
+            output_text="Made changes",
+            file_edits=[
+                FileEdit(path="file1.py", type="edit"),
+                FileEdit(path="file2.py", type="create"),
+                FileEdit(path="file3.py", type="delete"),
+            ],
+        )
+        assert InteractionClassifier.is_substantive(result) is True

--- a/tests/test_session_manager_interactions.py
+++ b/tests/test_session_manager_interactions.py
@@ -1,0 +1,349 @@
+"""Integration tests for SessionManager interaction tracking."""
+
+import pytest
+
+from src.agent_adapters.base import AgentResult, FileEdit
+from src.core.interaction_classifier import InteractionClassifier
+from src.core.models import (
+    Agent,
+    AgentType,
+    ConversationMessage,
+    Project,
+    WorkingDirMode,
+)
+from src.core.session_manager import SessionManager
+from pathlib import Path
+
+
+class TestSessionManagerInteractions:
+    """Test cases for SessionManager interaction tracking."""
+
+    @pytest.fixture
+    def session_manager(self):
+        """Create a SessionManager instance for testing."""
+        return SessionManager(history_limit=20)
+
+    @pytest.fixture
+    def classifier(self):
+        """Create an InteractionClassifier instance."""
+        return InteractionClassifier()
+
+    @pytest.fixture
+    def test_project(self, tmp_path):
+        """Create a test project."""
+        return Project(
+            id="test-project",
+            channel_name="test-channel",
+            path=tmp_path,
+            default_agent_id="claude",
+        )
+
+    def test_append_interaction_substantive(self, session_manager, classifier, test_project):
+        """Appending a substantive interaction should add it."""
+        session = session_manager.create_session(
+            project=test_project,
+            channel_id="C123",
+            thread_ts="1234567890.123456",
+            agent_id="claude",
+            agent_type=AgentType.CLAUDE,
+        )
+
+        user_msg = ConversationMessage(role="user", content="Add a component")
+        agent_result = AgentResult(
+            success=True,
+            output_text="Added component to the project",
+            file_edits=[FileEdit(path="component.py", type="create")],
+        )
+
+        session_manager.append_interaction(
+            session.id,
+            user_message=user_msg,
+            agent_result=agent_result,
+            classifier=classifier,
+        )
+
+        # Verify interaction was added
+        assert len(session.interactions) == 1
+        assert session.interactions[0].user_message.content == "Add a component"
+        assert session.interactions[0].agent_message.content == "Added component to the project"
+
+    def test_append_interaction_non_substantive(self, session_manager, classifier, test_project):
+        """Appending a non-substantive interaction should skip it."""
+        session = session_manager.create_session(
+            project=test_project,
+            channel_id="C123",
+            thread_ts="1234567890.123456",
+            agent_id="claude",
+            agent_type=AgentType.CLAUDE,
+        )
+
+        user_msg = ConversationMessage(role="user", content="What's the status?")
+        agent_result = AgentResult(
+            success=False,
+            output_text="",  # Empty text, not substantive
+        )
+
+        session_manager.append_interaction(
+            session.id,
+            user_message=user_msg,
+            agent_result=agent_result,
+            classifier=classifier,
+        )
+
+        # Should NOT add non-substantive interaction
+        assert len(session.interactions) == 0
+
+    def test_append_multiple_interactions(self, session_manager, classifier, test_project):
+        """Should track multiple interactions correctly."""
+        session = session_manager.create_session(
+            project=test_project,
+            channel_id="C123",
+            thread_ts="1234567890.123456",
+            agent_id="claude",
+            agent_type=AgentType.CLAUDE,
+        )
+
+        for i in range(5):
+            user_msg = ConversationMessage(role="user", content=f"Request {i+1}")
+            agent_result = AgentResult(
+                success=True,
+                output_text=f"Completed request {i+1}",
+            )
+
+            session_manager.append_interaction(
+                session.id,
+                user_message=user_msg,
+                agent_result=agent_result,
+                classifier=classifier,
+            )
+
+        assert len(session.interactions) == 5
+        # Check interaction numbers are 1-indexed
+        for i, interaction in enumerate(session.interactions):
+            assert interaction.interaction_number == i + 1
+
+    def test_summarization_at_10_interactions(self, session_manager, classifier, test_project):
+        """Summarization should trigger automatically at 10 interactions."""
+        session = session_manager.create_session(
+            project=test_project,
+            channel_id="C123",
+            thread_ts="1234567890.123456",
+            agent_id="claude",
+            agent_type=AgentType.CLAUDE,
+        )
+
+        # Add 10 interactions
+        for i in range(10):
+            user_msg = ConversationMessage(role="user", content=f"Request {i+1}")
+            agent_result = AgentResult(
+                success=True,
+                output_text=f"Completed request {i+1}",
+            )
+
+            session_manager.append_interaction(
+                session.id,
+                user_message=user_msg,
+                agent_result=agent_result,
+                classifier=classifier,
+            )
+
+        # After 10 interactions, summarization should have occurred
+        assert session.conversation_summary is not None
+        assert session.summary_interaction_count == 5
+
+        # First 5 should be marked as summarized
+        for i in range(5):
+            assert session.interactions[i].is_summarized is True
+
+        # Last 5 should not be summarized
+        for i in range(5, 10):
+            assert session.interactions[i].is_summarized is False
+
+    def test_get_context_for_agent_no_interactions(self, session_manager, test_project):
+        """Context with no interactions should be empty."""
+        session = session_manager.create_session(
+            project=test_project,
+            channel_id="C123",
+            thread_ts="1234567890.123456",
+            agent_id="claude",
+            agent_type=AgentType.CLAUDE,
+        )
+
+        context = session_manager.get_context_for_agent(session.id)
+        assert context == ""
+
+    def test_get_context_for_agent_with_interactions(self, session_manager, classifier, test_project):
+        """Context should include interactions."""
+        session = session_manager.create_session(
+            project=test_project,
+            channel_id="C123",
+            thread_ts="1234567890.123456",
+            agent_id="claude",
+            agent_type=AgentType.CLAUDE,
+        )
+
+        user_msg = ConversationMessage(role="user", content="Add CardList for 52 cards")
+        agent_result = AgentResult(
+            success=True,
+            output_text="Added CardList component with 52 cards",
+        )
+
+        session_manager.append_interaction(
+            session.id,
+            user_message=user_msg,
+            agent_result=agent_result,
+            classifier=classifier,
+        )
+
+        context = session_manager.get_context_for_agent(session.id)
+
+        assert "USER:" in context
+        assert "AGENT:" in context
+        assert "52 cards" in context
+
+    def test_get_context_for_agent_with_summary(self, session_manager, classifier, test_project):
+        """Context should include summary after 10 interactions."""
+        session = session_manager.create_session(
+            project=test_project,
+            channel_id="C123",
+            thread_ts="1234567890.123456",
+            agent_id="claude",
+            agent_type=AgentType.CLAUDE,
+        )
+
+        # Add 10 interactions to trigger summarization
+        for i in range(10):
+            user_msg = ConversationMessage(role="user", content=f"Request {i+1}")
+            agent_result = AgentResult(
+                success=True,
+                output_text=f"Completed {i+1}",
+            )
+
+            session_manager.append_interaction(
+                session.id,
+                user_message=user_msg,
+                agent_result=agent_result,
+                classifier=classifier,
+            )
+
+        context = session_manager.get_context_for_agent(session.id)
+
+        # Should include summary markers
+        assert "SUMMARY BEFORE THESE MESSAGES" in context
+        assert "MORE RECENT MESSAGES" in context
+
+    def test_should_summarize_at_exactly_10(self, session_manager, classifier, test_project):
+        """should_summarize should return True at exactly 10 interactions."""
+        session = session_manager.create_session(
+            project=test_project,
+            channel_id="C123",
+            thread_ts="1234567890.123456",
+            agent_id="claude",
+            agent_type=AgentType.CLAUDE,
+        )
+
+        # Add 9 interactions - should not summarize yet
+        for i in range(9):
+            user_msg = ConversationMessage(role="user", content=f"Request {i+1}")
+            agent_result = AgentResult(
+                success=True,
+                output_text=f"Completed {i+1}",
+            )
+
+            session_manager.append_interaction(
+                session.id,
+                user_message=user_msg,
+                agent_result=agent_result,
+                classifier=classifier,
+            )
+
+        assert session_manager.should_summarize(session.id) is False
+
+        # Add 10th interaction - now it should have summarized
+        user_msg = ConversationMessage(role="user", content="Request 10")
+        agent_result = AgentResult(
+            success=True,
+            output_text="Completed 10",
+        )
+
+        session_manager.append_interaction(
+            session.id,
+            user_message=user_msg,
+            agent_result=agent_result,
+            classifier=classifier,
+        )
+
+        # The append_interaction already triggered summarization internally
+        assert session.conversation_summary is not None
+
+    def test_interaction_numbers_are_1_indexed(self, session_manager, classifier, test_project):
+        """Interaction numbers should be 1-indexed."""
+        session = session_manager.create_session(
+            project=test_project,
+            channel_id="C123",
+            thread_ts="1234567890.123456",
+            agent_id="claude",
+            agent_type=AgentType.CLAUDE,
+        )
+
+        for i in range(3):
+            user_msg = ConversationMessage(role="user", content=f"Request {i+1}")
+            agent_result = AgentResult(
+                success=True,
+                output_text=f"Response {i+1}",
+            )
+
+            session_manager.append_interaction(
+                session.id,
+                user_message=user_msg,
+                agent_result=agent_result,
+                classifier=classifier,
+            )
+
+        assert session.interactions[0].interaction_number == 1
+        assert session.interactions[1].interaction_number == 2
+        assert session.interactions[2].interaction_number == 3
+
+    def test_only_substantive_counted_for_summarization(self, session_manager, classifier, test_project):
+        """Only substantive interactions should count toward summarization trigger."""
+        session = session_manager.create_session(
+            project=test_project,
+            channel_id="C123",
+            thread_ts="1234567890.123456",
+            agent_id="claude",
+            agent_type=AgentType.CLAUDE,
+        )
+
+        # Add 10 substantive interactions
+        for i in range(10):
+            user_msg = ConversationMessage(role="user", content=f"Request {i+1}")
+            agent_result = AgentResult(
+                success=True,
+                output_text=f"Response {i+1}",
+            )
+
+            session_manager.append_interaction(
+                session.id,
+                user_message=user_msg,
+                agent_result=agent_result,
+                classifier=classifier,
+            )
+
+        # Try to add a non-substantive interaction
+        user_msg = ConversationMessage(role="user", content="Status check")
+        agent_result = AgentResult(
+            success=False,
+            output_text="",
+        )
+
+        session_manager.append_interaction(
+            session.id,
+            user_message=user_msg,
+            agent_result=agent_result,
+            classifier=classifier,
+        )
+
+        # Should still have exactly 10 substantive interactions
+        assert len(session.interactions) == 10
+        # Summary should have been triggered
+        assert session.conversation_summary is not None


### PR DESCRIPTION
# Issue
Previously, we were always just taking the last 5 message and adding it without any kind of special restructuring making the context fuzzy around what the user's doing from one-shot to one-shot call.

# Changes
1. Improving this step by allowing the agent to handle more messages and also adding a summary step if there are more than 10 interactions (1 user + 1 agent message = 1 interaction).
2. That way, over time, we'll have better awareness than what's there currently.

<img width="465" height="384" alt="image" src="https://github.com/user-attachments/assets/7b39f3d4-f1ae-41be-975b-bc1d116b3dd2" />
