### PR TITLE
Add project from slack

### DIFF
--- a/config/agents.yaml
+++ b/config/agents.yaml
@@ -12,7 +12,7 @@ agents:
       - claude
       - --print
       - --permission-mode
-      - acceptEdits
+      - bypassPermissions
       - --output-format
       - stream-json
       - --verbose

--- a/src/chat_adapters/i_chat_adapter.py
+++ b/src/chat_adapters/i_chat_adapter.py
@@ -3,14 +3,21 @@
 from __future__ import annotations
 
 import abc
+from typing import Optional
 
 
 class IChatAdapter(abc.ABC):
     """Abstraction for chat platform integrations (Slack, Discord, etc.)."""
 
     @abc.abstractmethod
-    async def send_message(self, channel: str, thread_ts: str, text: str) -> None:
-        """Send a message to a channel/thread."""
+    async def send_message(
+        self, channel: str, thread_ts: str, text: str
+    ) -> Optional[str]:
+        """Send a message to a channel/thread.
+
+        Returns:
+            The message timestamp/ID if available, None otherwise.
+        """
 
     @abc.abstractmethod
     async def start(self) -> None:

--- a/src/chat_adapters/slack_adapter.py
+++ b/src/chat_adapters/slack_adapter.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from slack_sdk.errors import SlackApiError
 from slack_sdk.socket_mode.aiohttp import SocketModeClient
@@ -35,9 +35,14 @@ class SlackAdapter(IChatAdapter):
         self._channel_name_cache: Dict[str, str] = {}
         self._client.socket_mode_request_listeners.append(self._handle_socket_request)
 
-    async def send_message(self, channel: str, thread_ts: str, text: str) -> None:
+    async def send_message(
+        self, channel: str, thread_ts: str, text: str
+    ) -> Optional[str]:
         try:
-            await self._web_client.chat_postMessage(channel=channel, text=text, thread_ts=thread_ts)
+            response = await self._web_client.chat_postMessage(
+                channel=channel, text=text, thread_ts=thread_ts
+            )
+            return response.get("ts")
         except SlackApiError as exc:
             raise SlackError(f"Failed to send Slack message: {exc}") from exc
 

--- a/src/core/commands/project_creation.py
+++ b/src/core/commands/project_creation.py
@@ -1,0 +1,186 @@
+"""Handler for automatic project creation from Slack."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Dict, Optional
+
+from ..config import Config, load_config
+from ..project_creation import ProjectCreationRequest, ProjectCreationService
+from ...github import GitHubManager
+
+LOGGER = logging.getLogger(__name__)
+
+# Type alias for the message sender callback
+SendMessage = Callable[[str, str, str], Awaitable[Optional[str]]]
+
+
+@dataclass
+class PendingProjectCreation:
+    """Tracks a pending project creation prompt."""
+
+    channel_id: str
+    channel_name: str
+    thread_ts: str
+    created_at: float
+
+
+class ProjectCreationHandler:
+    """Handles automatic project creation when messaging unknown channels."""
+
+    def __init__(
+        self,
+        config: Config,
+        github_manager: GitHubManager,
+        config_root,
+    ) -> None:
+        self._config = config
+        self._config_root = config_root
+        self._pending_projects: Dict[str, PendingProjectCreation] = {}
+        self._project_creator = ProjectCreationService(
+            config=config,
+            github_manager=github_manager,
+        )
+
+    def update_config(self, config: Config) -> None:
+        """Update the config reference."""
+        self._config = config
+        self._project_creator.update_config(config)
+
+    async def handle_missing_project(
+        self,
+        channel_id: str,
+        channel_name: str,
+        thread_ts: str,
+        send_message: SendMessage,
+    ) -> None:
+        """
+        Handle a message to a channel without a configured project.
+
+        Sends a prompt asking the user if they want to create the project.
+        """
+        # Check if we already prompted for this channel
+        if channel_id in self._pending_projects:
+            LOGGER.debug("Project creation already pending for %s", channel_name)
+            return
+
+        # Send prompt message
+        await send_message(
+            channel_id,
+            thread_ts,
+            f"I couldn't find a project named **{channel_name}**. Is this a new idea?!?!\n\n"
+            "Reply with **Y** to create it, or **N** to cancel.",
+        )
+
+        # Track pending creation
+        self._pending_projects[channel_id] = PendingProjectCreation(
+            channel_id=channel_id,
+            channel_name=channel_name,
+            thread_ts=thread_ts,
+            created_at=time.time(),
+        )
+
+    async def handle_response(
+        self,
+        channel_id: str,
+        text: str,
+        send_message: SendMessage,
+    ) -> tuple[bool, Optional[Config]]:
+        """
+        Handle a potential Y/N response to a pending project creation prompt.
+
+        Args:
+            channel_id: The channel ID
+            text: The message text
+            send_message: Callback to send messages
+
+        Returns:
+            Tuple of (was_handled, new_config_if_created)
+            - was_handled: True if this was a response to a pending prompt
+            - new_config_if_created: New Config if project was created, None otherwise
+        """
+        pending = self._pending_projects.get(channel_id)
+        if not pending:
+            return False, None
+
+        response = text.strip().lower()
+
+        if response in ("y", "yes"):
+            del self._pending_projects[channel_id]
+            new_config = await self._handle_approval(pending, send_message)
+            return True, new_config
+        elif response in ("n", "no"):
+            del self._pending_projects[channel_id]
+            await self._handle_rejection(pending, send_message)
+            return True, None
+        else:
+            # Not a y/n response, remind them
+            await send_message(
+                pending.channel_id,
+                pending.thread_ts,
+                f"Please reply with **Y** to create project **{pending.channel_name}**, or **N** to cancel.",
+            )
+            return True, None
+
+    async def _handle_approval(
+        self,
+        pending: PendingProjectCreation,
+        send_message: SendMessage,
+    ) -> Optional[Config]:
+        """
+        Handle user approving project creation.
+
+        Returns:
+            New Config if successful, None on failure
+        """
+        await send_message(
+            pending.channel_id,
+            pending.thread_ts,
+            f"Creating project **{pending.channel_name}**...",
+        )
+
+        try:
+            request = ProjectCreationRequest(
+                project_id=pending.channel_name,
+                channel_name=pending.channel_name,
+                default_agent_id="claude",
+            )
+
+            await self._project_creator.create_project(request)
+
+            # Reload config
+            new_config = load_config(self._config_root)
+
+            await send_message(
+                pending.channel_id,
+                pending.thread_ts,
+                f"Okay great, I've set up **{pending.channel_name}**! "
+                "What's this new idea? What do you want me to do?",
+            )
+
+            return new_config
+
+        except Exception as e:
+            LOGGER.exception("Failed to create project %s", pending.channel_name)
+            await send_message(
+                pending.channel_id,
+                pending.thread_ts,
+                f"Sorry, I couldn't create the project: {e}",
+            )
+            return None
+
+    async def _handle_rejection(
+        self,
+        pending: PendingProjectCreation,
+        send_message: SendMessage,
+    ) -> None:
+        """Handle user rejecting project creation."""
+        await send_message(
+            pending.channel_id,
+            pending.thread_ts,
+            "Okay, if the project name is different, then rename the channel "
+            "and reload to try again. Otherwise, this channel won't be connected "
+            "to any of your repositories.",
+        )

--- a/src/core/commands/project_creation.py
+++ b/src/core/commands/project_creation.py
@@ -79,8 +79,9 @@ class ProjectCreationHandler:
         await send_message(
             channel_id,
             thread_ts,
-            f"I couldn't find a project named `{channel_name}`. Is this a new idea?!?!\n\n"
-            "Reply with \"Y\" to create it, or \"N\" to cancel.",
+            f"I couldn't find a project named `{channel_name}`. "
+            "Is this a new idea, or something that already exists on your computer?\n\n"
+            "Reply with \"Y\" to set it up, or \"N\" to cancel.",
         )
 
         # Track pending creation
@@ -246,11 +247,11 @@ class ProjectCreationHandler:
         Returns:
             New Config if successful, None on failure
         """
-        model_str = f"/{model}" if model else ""
+        model_str = f" {model}" if model else ""
         await send_message(
             pending.channel_id,
             pending.thread_ts,
-            f"Creating project `{pending.channel_name}` with `{agent_id} {model_str}`...",
+            f"Setting up project `{pending.channel_name}` with `{agent_id}{model_str}`...",
         )
 
         try:
@@ -268,8 +269,7 @@ class ProjectCreationHandler:
             await send_message(
                 pending.channel_id,
                 pending.thread_ts,
-                f"Okay great, I've set up `{pending.channel_name}`! "
-                "What's this new idea? What do you want me to do?",
+                f"Okay great, I've set up `{pending.channel_name}`! What do you want me to do?",
             )
 
             return new_config

--- a/src/core/commands/project_creation.py
+++ b/src/core/commands/project_creation.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass
-from typing import Awaitable, Callable, Dict, Optional
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Dict, List, Optional
 
 from ..config import Config, load_config
 from ..project_creation import ProjectCreationRequest, ProjectCreationService
@@ -16,6 +16,11 @@ LOGGER = logging.getLogger(__name__)
 # Type alias for the message sender callback
 SendMessage = Callable[[str, str, str], Awaitable[Optional[str]]]
 
+# States for the project creation flow
+STATE_AWAITING_CONFIRMATION = "awaiting_confirmation"
+STATE_AWAITING_AGENT = "awaiting_agent"
+STATE_AWAITING_MODEL = "awaiting_model"
+
 
 @dataclass
 class PendingProjectCreation:
@@ -25,6 +30,10 @@ class PendingProjectCreation:
     channel_name: str
     thread_ts: str
     created_at: float
+    state: str = STATE_AWAITING_CONFIRMATION
+    selected_agent_id: Optional[str] = None
+    agent_options: List[str] = field(default_factory=list)
+    model_options: List[str] = field(default_factory=list)
 
 
 class ProjectCreationHandler:
@@ -70,8 +79,8 @@ class ProjectCreationHandler:
         await send_message(
             channel_id,
             thread_ts,
-            f"I couldn't find a project named **{channel_name}**. Is this a new idea?!?!\n\n"
-            "Reply with **Y** to create it, or **N** to cancel.",
+            f"I couldn't find a project named `{channel_name}`. Is this a new idea?!?!\n\n"
+            "Reply with \"Y\" to create it, or \"N\" to cancel.",
         )
 
         # Track pending creation
@@ -89,17 +98,10 @@ class ProjectCreationHandler:
         send_message: SendMessage,
     ) -> tuple[bool, Optional[Config]]:
         """
-        Handle a potential Y/N response to a pending project creation prompt.
-
-        Args:
-            channel_id: The channel ID
-            text: The message text
-            send_message: Callback to send messages
+        Handle a response to a pending project creation prompt.
 
         Returns:
             Tuple of (was_handled, new_config_if_created)
-            - was_handled: True if this was a response to a pending prompt
-            - new_config_if_created: New Config if project was created, None otherwise
         """
         pending = self._pending_projects.get(channel_id)
         if not pending:
@@ -107,56 +109,166 @@ class ProjectCreationHandler:
 
         response = text.strip().lower()
 
+        if pending.state == STATE_AWAITING_CONFIRMATION:
+            return await self._handle_confirmation_response(pending, response, send_message)
+        elif pending.state == STATE_AWAITING_AGENT:
+            return await self._handle_agent_response(pending, response, send_message)
+        elif pending.state == STATE_AWAITING_MODEL:
+            return await self._handle_model_response(pending, response, send_message)
+
+        return False, None
+
+    async def _handle_confirmation_response(
+        self,
+        pending: PendingProjectCreation,
+        response: str,
+        send_message: SendMessage,
+    ) -> tuple[bool, Optional[Config]]:
+        """Handle Y/N confirmation response."""
         if response in ("y", "yes"):
-            del self._pending_projects[channel_id]
-            new_config = await self._handle_approval(pending, send_message)
-            return True, new_config
+            await self._show_agent_options(pending, send_message)
+            return True, None
         elif response in ("n", "no"):
-            del self._pending_projects[channel_id]
+            del self._pending_projects[pending.channel_id]
             await self._handle_rejection(pending, send_message)
             return True, None
         else:
-            # Not a y/n response, remind them
             await send_message(
                 pending.channel_id,
                 pending.thread_ts,
-                f"Please reply with **Y** to create project **{pending.channel_name}**, or **N** to cancel.",
+                f"Please reply with \"Y\" to create project `{pending.channel_name}`, or \"N\" to cancel.",
             )
             return True, None
 
-    async def _handle_approval(
+    async def _handle_agent_response(
+        self,
+        pending: PendingProjectCreation,
+        response: str,
+        send_message: SendMessage,
+    ) -> tuple[bool, Optional[Config]]:
+        """Handle agent selection response."""
+        try:
+            choice = int(response)
+            if 1 <= choice <= len(pending.agent_options):
+                pending.selected_agent_id = pending.agent_options[choice - 1]
+                await self._show_model_options(pending, send_message)
+                return True, None
+        except ValueError:
+            pass
+
+        await send_message(
+            pending.channel_id,
+            pending.thread_ts,
+            f"Please reply with the number corresponding to the agent.",
+        )
+        return True, None
+
+    async def _handle_model_response(
+        self,
+        pending: PendingProjectCreation,
+        response: str,
+        send_message: SendMessage,
+    ) -> tuple[bool, Optional[Config]]:
+        """Handle model selection response."""
+        try:
+            choice = int(response)
+            if 1 <= choice <= len(pending.model_options):
+                selected_model = pending.model_options[choice - 1]
+                del self._pending_projects[pending.channel_id]
+                new_config = await self._create_project(
+                    pending, pending.selected_agent_id, selected_model, send_message
+                )
+                return True, new_config
+        except ValueError:
+            pass
+
+        await send_message(
+            pending.channel_id,
+            pending.thread_ts,
+            f"Please reply with the number corresponding to the model.",
+        )
+        return True, None
+
+    async def _show_agent_options(
         self,
         pending: PendingProjectCreation,
         send_message: SendMessage,
+    ) -> None:
+        """Show available agents for selection."""
+        pending.agent_options = list(self._config.agents.keys())
+        pending.state = STATE_AWAITING_AGENT
+
+        lines = ["Which agent should I use for this project?\n"]
+        for i, agent_id in enumerate(pending.agent_options, 1):
+            lines.append(f"{i}. {agent_id}")
+        lines.append("\nReply with the number.")
+
+        await send_message(pending.channel_id, pending.thread_ts, "\n".join(lines))
+
+    async def _show_model_options(
+        self,
+        pending: PendingProjectCreation,
+        send_message: SendMessage,
+    ) -> None:
+        """Show available models for the selected agent."""
+        agent = self._config.agents.get(pending.selected_agent_id)
+        if agent and agent.models:
+            pending.model_options = agent.models.get("available", [])
+        else:
+            pending.model_options = []
+
+        if not pending.model_options:
+            del self._pending_projects[pending.channel_id]
+            new_config = await self._create_project(
+                pending, pending.selected_agent_id, None, send_message
+            )
+            return
+
+        pending.state = STATE_AWAITING_MODEL
+
+        lines = [f"Which model for `{pending.selected_agent_id}`?\n"]
+        for i, model in enumerate(pending.model_options, 1):
+            lines.append(f"{i}. {model}")
+        lines.append("\nReply with the number.")
+
+        await send_message(pending.channel_id, pending.thread_ts, "\n".join(lines))
+
+    async def _create_project(
+        self,
+        pending: PendingProjectCreation,
+        agent_id: str,
+        model: Optional[str],
+        send_message: SendMessage,
     ) -> Optional[Config]:
         """
-        Handle user approving project creation.
+        Create the project with selected agent and model.
 
         Returns:
             New Config if successful, None on failure
         """
+        model_str = f"/{model}" if model else ""
         await send_message(
             pending.channel_id,
             pending.thread_ts,
-            f"Creating project **{pending.channel_name}**...",
+            f"Creating project `{pending.channel_name}` with `{agent_id} {model_str}`...",
         )
 
         try:
             request = ProjectCreationRequest(
                 project_id=pending.channel_name,
                 channel_name=pending.channel_name,
-                default_agent_id="claude",
+                default_agent_id=agent_id,
+                default_model=model,
             )
 
             await self._project_creator.create_project(request)
 
-            # Reload config
             new_config = load_config(self._config_root)
 
             await send_message(
                 pending.channel_id,
                 pending.thread_ts,
-                f"Okay great, I've set up **{pending.channel_name}**! "
+                f"Okay great, I've set up `{pending.channel_name}`! "
                 "What's this new idea? What do you want me to do?",
             )
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -29,6 +29,8 @@ class Config:
     slack_bot_token: str
     slack_app_token: str
     slack_allowed_user_ids: list[str]
+    base_dir: Path
+    config_dir: Path
     github_token: str | None = None
 
     def get_project_by_channel(self, channel: str) -> Project:
@@ -74,7 +76,7 @@ def load_config(config_dir: Path | str | None = None) -> Config:
 def _load_config_from_root(root: Path) -> Config:
     _load_env_file(root / ENV_FILE_NAME)
 
-    projects = _load_projects(root / PROJECTS_FILE)
+    projects, base_dir = _load_projects(root / PROJECTS_FILE)
     agents = _select_agents(_load_agents(root / AGENTS_FILE))
 
     slack_bot_token = _require_env("SLACK_BOT_TOKEN")
@@ -88,6 +90,8 @@ def _load_config_from_root(root: Path) -> Config:
         slack_bot_token=slack_bot_token,
         slack_app_token=slack_app_token,
         slack_allowed_user_ids=slack_allowed_user_ids,
+        base_dir=base_dir,
+        config_dir=root,
         github_token=github_token,
     )
 
@@ -113,7 +117,7 @@ def _load_allowed_user_ids() -> list[str]:
     return [uid.strip() for uid in raw_value.split(",") if uid.strip()]
 
 
-def _load_projects(path: Path) -> Dict[str, Project]:
+def _load_projects(path: Path) -> Tuple[Dict[str, Project], Path]:
     try:
         data = yaml.safe_load(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
@@ -170,7 +174,7 @@ def _load_projects(path: Path) -> Dict[str, Project]:
         )
     if not projects:
         LOGGER.warning("No projects configured in %s", path)
-    return projects
+    return projects, base_dir
 
 
 def _load_agents(path: Path) -> Dict[str, Agent]:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -153,6 +153,8 @@ def _load_projects(path: Path) -> Tuple[Dict[str, Project], Path]:
         if not default_agent:
             raise ConfigError(f"Project {project_id} missing default_agent")
 
+        default_model = cfg.get("default_model")
+
         github_cfg = cfg.get("github")
         github = None
         if github_cfg:
@@ -170,6 +172,7 @@ def _load_projects(path: Path) -> Tuple[Dict[str, Project], Path]:
             channel_name=project_id,
             path=full_path,
             default_agent_id=default_agent,
+            default_model=default_model,
             github=github,
         )
     if not projects:

--- a/src/core/errors.py
+++ b/src/core/errors.py
@@ -35,3 +35,8 @@ class SlackError(RemoteCoderError):
 
 class GitHubError(RemoteCoderError):
     pass
+
+
+class ProjectCreationError(RemoteCoderError):
+    """Raised when project creation fails."""
+    pass

--- a/src/core/errors.py
+++ b/src/core/errors.py
@@ -40,3 +40,13 @@ class GitHubError(RemoteCoderError):
 class ProjectCreationError(RemoteCoderError):
     """Raised when project creation fails."""
     pass
+
+
+class RepoExistsError(ProjectCreationError):
+    """Raised when GitHub repo name already exists."""
+    pass
+
+
+class LocalDirNotGitRepoError(ProjectCreationError):
+    """Raised when local directory exists but is not a git repository."""
+    pass

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -35,6 +35,7 @@ class Project:
     path: Path
     default_agent_id: str
     github: Optional[GitHubRepoConfig] = None
+    default_model: Optional[str] = None
 
 
 class SessionStatus(str, Enum):

--- a/src/core/project_creation.py
+++ b/src/core/project_creation.py
@@ -183,9 +183,6 @@ class ProjectCreationService:
             )
             LOGGER.info("Pushed to GitHub")
 
-            # After successful push, update remote to use SSH for future operations
-            await self._run_git(local_path, ["remote", "set-url", "origin", f"git@github.com:{repo_full_name}.git"])
-
             project = await self._add_to_config(
                 project_id=repo_name,
                 channel_name=request.channel_name,

--- a/src/core/project_creation.py
+++ b/src/core/project_creation.py
@@ -1,0 +1,310 @@
+"""Service for creating new projects with GitHub integration."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from .config import Config
+from .errors import GitHubError, ProjectCreationError, ProjectNotFound
+from .models import GitHubRepoConfig, Project
+from ..github import GitHubManager
+
+LOGGER = logging.getLogger(__name__)
+
+# Valid project ID pattern: alphanumeric, hyphens, underscores
+PROJECT_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
+
+
+@dataclass
+class ProjectCreationRequest:
+    """Configuration for creating a new project."""
+
+    project_id: str
+    channel_name: str
+    default_agent_id: str = "claude"
+    default_base_branch: str = "main"
+
+
+class ProjectCreationService:
+    """Encapsulates project creation workflow."""
+
+    def __init__(
+        self,
+        config: Config,
+        github_manager: GitHubManager,
+    ) -> None:
+        self._config = config
+        self._github = github_manager
+
+    def update_config(self, config: Config) -> None:
+        """Update the config reference."""
+        self._config = config
+
+    async def create_project(self, request: ProjectCreationRequest) -> Project:
+        """
+        Create a new project with local directory and GitHub repo.
+
+        Steps:
+        1. Validate project ID and ensure project doesn't exist
+        2. Create local directory
+        3. Initialize git repository
+        4. Create GitHub repository (private)
+        5. Add initial commit (README.md)
+        6. Push to GitHub
+        7. Update projects.yaml
+
+        Returns:
+            Created Project object
+
+        Raises:
+            ProjectCreationError: If any step fails
+        """
+        project_id = request.project_id
+
+        # Validate project ID
+        self._validate_project_id(project_id)
+
+        local_path = self._config.base_dir / project_id
+
+        # Validate project doesn't exist
+        if local_path.exists():
+            raise ProjectCreationError(f"Directory already exists: {local_path}")
+
+        try:
+            self._config.get_project_by_channel(project_id)
+            raise ProjectCreationError(f"Project '{project_id}' is already configured")
+        except ProjectNotFound:
+            pass  # Good, doesn't exist
+
+        try:
+            # Get GitHub owner
+            github_owner = await self._get_github_owner()
+
+            # Create local directory
+            local_path.mkdir(parents=True, exist_ok=False)
+            LOGGER.info("Created local directory: %s", local_path)
+
+            # Initialize git
+            await self._init_git_repo(local_path, request.default_base_branch)
+            LOGGER.info("Initialized git repository")
+
+            # Create GitHub repo
+            repo_full_name = await self._create_github_repo(
+                owner=github_owner,
+                repo_name=project_id,
+                description=f"Created from Slack channel #{request.channel_name}",
+            )
+            LOGGER.info("Created GitHub repository: %s", repo_full_name)
+
+            # Add initial commit
+            await self._create_initial_commit(
+                local_path, project_id, request.channel_name
+            )
+            LOGGER.info("Created initial commit")
+
+            # Push to GitHub
+            remote_url = f"git@github.com:{repo_full_name}.git"
+            await self._push_to_github(
+                local_path, remote_url, request.default_base_branch
+            )
+            LOGGER.info("Pushed to GitHub")
+
+            # Update projects.yaml
+            project = await self._add_to_config(
+                project_id=project_id,
+                channel_name=request.channel_name,
+                local_path=local_path,
+                github_owner=github_owner,
+                repo_name=project_id,
+                default_base_branch=request.default_base_branch,
+                default_agent_id=request.default_agent_id,
+            )
+            LOGGER.info("Updated projects.yaml")
+
+            return project
+
+        except ProjectCreationError:
+            # Cleanup and re-raise
+            self._cleanup_failed_creation(local_path)
+            raise
+        except Exception as e:
+            # Cleanup on unexpected failure
+            self._cleanup_failed_creation(local_path)
+            raise ProjectCreationError(
+                f"Failed to create project '{project_id}': {e}"
+            ) from e
+
+    def _validate_project_id(self, project_id: str) -> None:
+        """Validate project ID for safety and compatibility."""
+        if not project_id:
+            raise ProjectCreationError("Project ID cannot be empty")
+
+        if len(project_id) > 100:
+            raise ProjectCreationError("Project ID too long (max 100 characters)")
+
+        # Prevent directory traversal
+        if ".." in project_id or "/" in project_id or "\\" in project_id:
+            raise ProjectCreationError(
+                "Project ID cannot contain path separators or '..'"
+            )
+
+        if not PROJECT_ID_PATTERN.match(project_id):
+            raise ProjectCreationError(
+                "Project ID must start with alphanumeric and contain only "
+                "alphanumeric characters, hyphens, or underscores"
+            )
+
+    async def _get_github_owner(self) -> str:
+        """Get the GitHub owner/username for creating repos."""
+        if not self._github.is_configured():
+            raise GitHubError("GitHub token is not configured")
+
+        def _get_user_login() -> str:
+            user = self._github._client.get_user()
+            return user.login
+
+        return await asyncio.to_thread(_get_user_login)
+
+    async def _init_git_repo(self, path: Path, default_branch: str) -> None:
+        """Initialize a git repository."""
+        await self._run_git(path, ["init"])
+        await self._run_git(path, ["branch", "-M", default_branch])
+
+    async def _create_github_repo(
+        self,
+        owner: str,
+        repo_name: str,
+        description: str,
+    ) -> str:
+        """
+        Create a private GitHub repository.
+
+        Returns:
+            Full repository name (owner/repo)
+        """
+
+        def _create_repo() -> str:
+            user = self._github._client.get_user()
+            repo = user.create_repo(
+                name=repo_name,
+                description=description,
+                private=True,
+                auto_init=False,
+            )
+            return repo.full_name
+
+        try:
+            return await asyncio.to_thread(_create_repo)
+        except Exception as e:
+            raise GitHubError(f"Failed to create GitHub repository: {e}") from e
+
+    async def _create_initial_commit(
+        self,
+        path: Path,
+        project_id: str,
+        channel_name: str,
+    ) -> None:
+        """Create initial README and commit."""
+        readme = path / "README.md"
+        readme.write_text(
+            f"# {project_id}\n\nCreated from Slack channel #{channel_name}\n"
+        )
+        await self._run_git(path, ["add", "README.md"])
+        await self._run_git(path, ["commit", "-m", "Initial commit"])
+
+    async def _push_to_github(
+        self,
+        path: Path,
+        remote_url: str,
+        default_branch: str,
+    ) -> None:
+        """Add remote and push."""
+        await self._run_git(path, ["remote", "add", "origin", remote_url])
+        await self._run_git(path, ["push", "-u", "origin", default_branch])
+
+    async def _add_to_config(
+        self,
+        project_id: str,
+        channel_name: str,
+        local_path: Path,
+        github_owner: str,
+        repo_name: str,
+        default_base_branch: str,
+        default_agent_id: str,
+    ) -> Project:
+        """Add project entry to projects.yaml."""
+        projects_yaml = self._config.config_dir / "projects.yaml"
+
+        # Load existing
+        with open(projects_yaml, "r") as f:
+            data = yaml.safe_load(f) or {}
+
+        if "projects" not in data:
+            data["projects"] = {}
+
+        # Add new project - use relative path from base_dir
+        try:
+            relative_path = local_path.relative_to(self._config.base_dir)
+        except ValueError:
+            # If local_path is not relative to base_dir, use the full path
+            relative_path = local_path
+
+        data["projects"][project_id] = {
+            "path": str(relative_path),
+            "default_agent": default_agent_id,
+            "github": {
+                "owner": github_owner,
+                "repo": repo_name,
+                "default_base_branch": default_base_branch,
+            },
+        }
+
+        # Write back
+        with open(projects_yaml, "w") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+        # Create Project object
+        return Project(
+            id=project_id,
+            channel_name=channel_name,
+            path=local_path,
+            default_agent_id=default_agent_id,
+            github=GitHubRepoConfig(
+                owner=github_owner,
+                repo=repo_name,
+                default_base_branch=default_base_branch,
+            ),
+        )
+
+    async def _run_git(self, cwd: Path, args: list[str]) -> str:
+        """Run a git command asynchronously."""
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            *args,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+
+        if proc.returncode != 0:
+            error_msg = stderr.decode().strip() if stderr else "Unknown error"
+            raise ProjectCreationError(f"Git command failed: git {' '.join(args)}: {error_msg}")
+
+        return stdout.decode().strip() if stdout else ""
+
+    def _cleanup_failed_creation(self, path: Path) -> None:
+        """Clean up local directory on failure."""
+        if path.exists():
+            try:
+                shutil.rmtree(path)
+                LOGGER.info("Cleaned up failed creation: %s", path)
+            except Exception as e:
+                LOGGER.warning("Failed to cleanup %s: %s", path, e)

--- a/src/core/router.py
+++ b/src/core/router.py
@@ -263,7 +263,15 @@ class Router:
                 )
             return
 
-        await self._agent_runner.run(session, project, channel_id, thread_ts, user_text)
+        try:
+            await self._agent_runner.run(session, project, channel_id, thread_ts, user_text)
+        except Exception as exc:
+            LOGGER.exception("Unexpected error during agent interaction for session %s", session.id)
+            await self._send_message(
+                channel_id,
+                thread_ts,
+                f"Something went wrong: {exc}",
+            )
 
     async def _handle_command(
         self,

--- a/src/github/client.py
+++ b/src/github/client.py
@@ -48,6 +48,11 @@ class GitHubManager:
     def is_configured(self) -> bool:
         return self._client is not None
 
+    @property
+    def token(self) -> Optional[str]:
+        """Get the GitHub token for git operations."""
+        return self._token
+
     async def ensure_pull_request(
         self,
         project: Project,

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -49,7 +49,7 @@ def test_project(tmp_path):
 
 
 @pytest.fixture
-def test_config():
+def test_config(tmp_path):
     """Create a real Config with agents suitable for tests."""
     agents = {
         "claude": Agent(
@@ -74,6 +74,8 @@ def test_config():
         slack_bot_token="bot-token",
         slack_app_token="app-token",
         slack_allowed_user_ids=["U123"],
+        base_dir=tmp_path / "projects",
+        config_dir=tmp_path / "config",
         github_token=None,
     )
     return config

--- a/tests/test_project_creation.py
+++ b/tests/test_project_creation.py
@@ -1,0 +1,242 @@
+"""Tests for ProjectCreationService."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.core.config import Config
+from src.core.errors import GitHubError, ProjectCreationError, ProjectNotFound
+from src.core.models import Agent, AgentType, GitHubRepoConfig, Project, WorkingDirMode
+from src.core.project_creation import ProjectCreationRequest, ProjectCreationService
+
+
+@pytest.fixture
+def test_config(tmp_path):
+    """Create a test config with base_dir and config_dir."""
+    base_dir = tmp_path / "projects"
+    base_dir.mkdir()
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    # Create projects.yaml
+    projects_yaml = config_dir / "projects.yaml"
+    projects_yaml.write_text(f'base_dir: "{base_dir}"\nprojects: {{}}\n')
+
+    return Config(
+        projects={},
+        agents={
+            "claude": Agent(
+                id="claude",
+                type=AgentType.CLAUDE,
+                command=["claude"],
+                working_dir_mode=WorkingDirMode.PROJECT,
+            ),
+        },
+        slack_bot_token="bot-token",
+        slack_app_token="app-token",
+        slack_allowed_user_ids=["U123"],
+        base_dir=base_dir,
+        config_dir=config_dir,
+        github_token="test-token",
+    )
+
+
+@pytest.fixture
+def mock_github_manager():
+    """Create a mock GitHubManager."""
+    manager = MagicMock()
+    manager.is_configured.return_value = True
+    manager._client = MagicMock()
+
+    # Mock user
+    mock_user = MagicMock()
+    mock_user.login = "test-user"
+
+    # Mock repo creation
+    mock_repo = MagicMock()
+    mock_repo.full_name = "test-user/test-project"
+
+    mock_user.create_repo.return_value = mock_repo
+    manager._client.get_user.return_value = mock_user
+
+    return manager
+
+
+class TestProjectCreationService:
+    """Tests for ProjectCreationService."""
+
+    def test_validate_project_id_empty(self, test_config, mock_github_manager):
+        """Test that empty project ID raises error."""
+        service = ProjectCreationService(test_config, mock_github_manager)
+        with pytest.raises(ProjectCreationError, match="cannot be empty"):
+            service._validate_project_id("")
+
+    def test_validate_project_id_too_long(self, test_config, mock_github_manager):
+        """Test that overly long project ID raises error."""
+        service = ProjectCreationService(test_config, mock_github_manager)
+        with pytest.raises(ProjectCreationError, match="too long"):
+            service._validate_project_id("a" * 101)
+
+    def test_validate_project_id_path_traversal(self, test_config, mock_github_manager):
+        """Test that path traversal attempts are blocked."""
+        service = ProjectCreationService(test_config, mock_github_manager)
+        with pytest.raises(ProjectCreationError, match="path separators"):
+            service._validate_project_id("../evil")
+        with pytest.raises(ProjectCreationError, match="path separators"):
+            service._validate_project_id("foo/bar")
+        with pytest.raises(ProjectCreationError, match="path separators"):
+            service._validate_project_id("foo\\bar")
+
+    def test_validate_project_id_invalid_chars(self, test_config, mock_github_manager):
+        """Test that invalid characters are rejected."""
+        service = ProjectCreationService(test_config, mock_github_manager)
+        with pytest.raises(ProjectCreationError, match="must start with alphanumeric"):
+            service._validate_project_id("-starts-with-dash")
+        with pytest.raises(ProjectCreationError, match="must start with alphanumeric"):
+            service._validate_project_id("_starts-with-underscore")
+
+    def test_validate_project_id_valid(self, test_config, mock_github_manager):
+        """Test that valid project IDs pass validation."""
+        service = ProjectCreationService(test_config, mock_github_manager)
+        # These should not raise
+        service._validate_project_id("my-project")
+        service._validate_project_id("my_project")
+        service._validate_project_id("MyProject123")
+        service._validate_project_id("a")
+
+    @pytest.mark.asyncio
+    async def test_create_project_directory_exists(
+        self, test_config, mock_github_manager
+    ):
+        """Test that creating a project fails if directory exists."""
+        service = ProjectCreationService(test_config, mock_github_manager)
+
+        # Create the directory first
+        (test_config.base_dir / "existing-project").mkdir()
+
+        request = ProjectCreationRequest(
+            project_id="existing-project",
+            channel_name="existing-project",
+        )
+
+        with pytest.raises(ProjectCreationError, match="Directory already exists"):
+            await service.create_project(request)
+
+    @pytest.mark.asyncio
+    async def test_create_project_already_configured(
+        self, test_config, mock_github_manager
+    ):
+        """Test that creating an already configured project fails."""
+        # Add project to config
+        test_config.projects["test-project"] = Project(
+            id="test-project",
+            channel_name="test-project",
+            path=test_config.base_dir / "test-project",
+            default_agent_id="claude",
+        )
+
+        service = ProjectCreationService(test_config, mock_github_manager)
+        request = ProjectCreationRequest(
+            project_id="test-project",
+            channel_name="test-project",
+        )
+
+        with pytest.raises(ProjectCreationError, match="already configured"):
+            await service.create_project(request)
+
+    @pytest.mark.asyncio
+    async def test_create_project_github_not_configured(self, test_config):
+        """Test that creating a project fails if GitHub is not configured."""
+        mock_github = MagicMock()
+        mock_github.is_configured.return_value = False
+
+        service = ProjectCreationService(test_config, mock_github)
+        request = ProjectCreationRequest(
+            project_id="new-project",
+            channel_name="new-project",
+        )
+
+        with pytest.raises(ProjectCreationError, match="not configured"):
+            await service.create_project(request)
+
+    @pytest.mark.asyncio
+    async def test_create_project_success(self, test_config, mock_github_manager):
+        """Test successful project creation."""
+        service = ProjectCreationService(test_config, mock_github_manager)
+
+        # Mock git commands to succeed
+        with patch.object(service, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.return_value = ""
+
+            request = ProjectCreationRequest(
+                project_id="new-project",
+                channel_name="new-project",
+                default_agent_id="claude",
+                default_base_branch="main",
+            )
+
+            project = await service.create_project(request)
+
+            assert project.id == "new-project"
+            assert project.channel_name == "new-project"
+            assert project.default_agent_id == "claude"
+            assert project.github is not None
+            assert project.github.owner == "test-user"
+            assert project.github.repo == "new-project"
+            assert project.github.default_base_branch == "main"
+
+            # Verify local directory was created
+            assert (test_config.base_dir / "new-project").exists()
+            assert (test_config.base_dir / "new-project" / "README.md").exists()
+
+            # Verify projects.yaml was updated
+            import yaml
+
+            projects_yaml = test_config.config_dir / "projects.yaml"
+            with open(projects_yaml) as f:
+                data = yaml.safe_load(f)
+
+            assert "new-project" in data["projects"]
+            assert data["projects"]["new-project"]["default_agent"] == "claude"
+            assert data["projects"]["new-project"]["github"]["owner"] == "test-user"
+
+    @pytest.mark.asyncio
+    async def test_create_project_cleanup_on_failure(
+        self, test_config, mock_github_manager
+    ):
+        """Test that failed creation cleans up local directory."""
+        service = ProjectCreationService(test_config, mock_github_manager)
+
+        # Mock git init to succeed but push to fail
+        call_count = 0
+
+        async def mock_git(cwd, args):
+            nonlocal call_count
+            call_count += 1
+            if "push" in args:
+                raise ProjectCreationError("Push failed")
+            return ""
+
+        with patch.object(service, "_run_git", side_effect=mock_git):
+            request = ProjectCreationRequest(
+                project_id="failed-project",
+                channel_name="failed-project",
+            )
+
+            with pytest.raises(ProjectCreationError, match="Push failed"):
+                await service.create_project(request)
+
+            # Verify local directory was cleaned up
+            assert not (test_config.base_dir / "failed-project").exists()
+
+    def test_update_config(self, test_config, mock_github_manager):
+        """Test that update_config updates the internal config reference."""
+        service = ProjectCreationService(test_config, mock_github_manager)
+
+        new_config = MagicMock()
+        service.update_config(new_config)
+
+        assert service._config is new_config

--- a/tests/test_router_integration.py
+++ b/tests/test_router_integration.py
@@ -37,9 +37,13 @@ class DummyChatAdapter:
 
     def __init__(self) -> None:
         self.messages: list[Dict[str, str]] = []
+        self._msg_counter = 0
 
-    async def send_message(self, channel: str, thread_ts: str, text: str) -> None:
+    async def send_message(self, channel: str, thread_ts: str, text: str) -> str:
+        self._msg_counter += 1
+        msg_ts = f"{thread_ts}.{self._msg_counter}"
         self.messages.append({"channel": channel, "thread_ts": thread_ts, "text": text})
+        return msg_ts
 
 
 @pytest.fixture
@@ -68,6 +72,8 @@ def router_setup(tmp_path):
         slack_bot_token="x",
         slack_app_token="y",
         slack_allowed_user_ids=["U123"],
+        base_dir=tmp_path / "projects",
+        config_dir=tmp_path / "config",
         github_token=None,
     )
     github_manager = StubGitHubManager()

--- a/tests/test_router_reactions.py
+++ b/tests/test_router_reactions.py
@@ -242,7 +242,7 @@ class TestRouterYesNoHandling:
 
             mock_create.assert_called_once()
 
-        assert any("Creating project" in msg["text"] for msg in adapter.messages)
+        assert any("Setting up project" in msg["text"] for msg in adapter.messages)
         assert any("I've set up" in msg["text"] for msg in adapter.messages)
         assert "C123" not in router._project_creation_handler._pending_projects
 

--- a/tests/test_router_reactions.py
+++ b/tests/test_router_reactions.py
@@ -1,0 +1,451 @@
+"""Tests for Router project creation flow with Y/N text responses."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.core.config import Config
+from src.core.models import Agent, AgentType, GitHubRepoConfig, Project, WorkingDirMode
+from src.core.commands.project_creation import PendingProjectCreation
+from src.core.router import Router
+from src.core.conversation.session_manager import SessionManager
+
+
+class StubGitHubManager:
+    """Minimal GitHub manager stub for tests."""
+
+    def __init__(self) -> None:
+        self.token = None
+        self._client = MagicMock()
+
+    def update_token(self, token: str | None) -> None:
+        self.token = token
+
+    def is_configured(self) -> bool:
+        return True
+
+    async def get_unresolved_comments(self, *args: Any, **kwargs: Any):
+        return []
+
+    async def ensure_pull_request(self, *args: Any, **kwargs: Any):
+        raise AssertionError("PR publishing should not occur in these tests")
+
+
+class DummyChatAdapter:
+    """Captures Slack messages emitted by the router."""
+
+    def __init__(self) -> None:
+        self.messages: list[Dict[str, str]] = []
+        self._msg_counter = 0
+
+    async def send_message(
+        self, channel: str, thread_ts: str, text: str
+    ) -> Optional[str]:
+        self._msg_counter += 1
+        msg_ts = f"{thread_ts}.{self._msg_counter}"
+        self.messages.append(
+            {"channel": channel, "thread_ts": thread_ts, "text": text, "ts": msg_ts}
+        )
+        return msg_ts
+
+
+@pytest.fixture
+def router_setup(tmp_path):
+    """Set up a router for testing with no projects configured."""
+    session_manager = SessionManager(history_limit=20)
+    base_dir = tmp_path / "projects"
+    base_dir.mkdir()
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    # Create projects.yaml
+    projects_yaml = config_dir / "projects.yaml"
+    projects_yaml.write_text(f'base_dir: "{base_dir}"\nprojects: {{}}\n')
+
+    # Create agents.yaml (needed for config reload)
+    agents_yaml = config_dir / "agents.yaml"
+    agents_yaml.write_text("""agents:
+  claude:
+    type: claude
+    command: ["echo"]
+    working_dir_mode: project
+    models:
+      default: sonnet
+      available: ["sonnet"]
+""")
+
+    # Create .env file (needed for config reload)
+    env_file = config_dir / ".env"
+    env_file.write_text("""SLACK_BOT_TOKEN=x
+SLACK_APP_TOKEN=y
+SLACK_ALLOWED_USER_IDS=U123
+GITHUB_TOKEN=test-token
+""")
+
+    agent = Agent(
+        id="claude",
+        type=AgentType.CLAUDE,
+        command=["echo"],
+        working_dir_mode=WorkingDirMode.PROJECT,
+        models={"default": "sonnet", "available": ["sonnet"]},
+    )
+    config = Config(
+        projects={},  # No projects configured
+        agents={agent.id: agent},
+        slack_bot_token="x",
+        slack_app_token="y",
+        slack_allowed_user_ids=["U123"],
+        base_dir=base_dir,
+        config_dir=config_dir,
+        github_token="test-token",
+    )
+    github_manager = StubGitHubManager()
+    router = Router(session_manager, config, github_manager, config_root=config_dir)
+    router._git_workflow.setup_session_branch = AsyncMock(return_value=None)
+    router._git_workflow.maybe_publish_code_changes = AsyncMock(return_value=None)
+    router._agent_runner.run = AsyncMock()
+
+    adapter = DummyChatAdapter()
+    router.bind_adapter(adapter)
+    return router, adapter, tmp_path
+
+
+class TestPendingProjectCreation:
+    """Tests for PendingProjectCreation dataclass."""
+
+    def test_pending_project_creation_fields(self):
+        """Test PendingProjectCreation has expected fields."""
+        pending = PendingProjectCreation(
+            channel_id="C123",
+            channel_name="my-project",
+            thread_ts="111.000",
+            created_at=1234567890.0,
+        )
+        assert pending.channel_id == "C123"
+        assert pending.channel_name == "my-project"
+        assert pending.thread_ts == "111.000"
+        assert pending.created_at == 1234567890.0
+
+
+class TestRouterMissingProject:
+    """Tests for handling messages to channels without projects."""
+
+    @pytest.mark.asyncio
+    async def test_missing_project_sends_prompt(self, router_setup):
+        """Test that message to unknown channel sends creation prompt."""
+        router, adapter, _ = router_setup
+
+        event = {
+            "channel": "C123",
+            "channel_name": "new-idea",
+            "text": "Hello",
+            "ts": "111.222",
+        }
+
+        await router.handle_message(event)
+
+        # Should have sent the prompt message
+        assert len(adapter.messages) == 1
+        assert "new-idea" in adapter.messages[0]["text"]
+        assert "Reply with **Y**" in adapter.messages[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_missing_project_tracks_pending(self, router_setup):
+        """Test that pending project creation is tracked."""
+        router, adapter, _ = router_setup
+
+        event = {
+            "channel": "C123",
+            "channel_name": "new-idea",
+            "text": "Hello",
+            "ts": "111.222",
+        }
+
+        await router.handle_message(event)
+
+        # Should be tracking the pending creation by channel_id
+        handler = router._project_creation_handler
+        assert "C123" in handler._pending_projects
+        pending = handler._pending_projects["C123"]
+        assert pending.channel_id == "C123"
+        assert pending.channel_name == "new-idea"
+
+
+class TestRouterYesNoHandling:
+    """Tests for Y/N response handling in Router."""
+
+    @pytest.mark.asyncio
+    async def test_yes_response_creates_project(self, router_setup):
+        """Test that 'Y' response triggers project creation."""
+        router, adapter, tmp_path = router_setup
+
+        # First, send a message to trigger the prompt
+        event1 = {
+            "channel": "C123",
+            "channel_name": "new-idea",
+            "text": "Hello",
+            "ts": "111.222",
+        }
+        await router.handle_message(event1)
+
+        # Now send 'Y' response
+        with patch.object(
+            router._project_creation_handler._project_creator, "create_project", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = Project(
+                id="new-idea",
+                channel_name="new-idea",
+                path=tmp_path / "projects" / "new-idea",
+                default_agent_id="claude",
+                github=GitHubRepoConfig(
+                    owner="test-user",
+                    repo="new-idea",
+                    default_base_branch="main",
+                ),
+            )
+
+            event2 = {
+                "channel": "C123",
+                "channel_name": "new-idea",
+                "text": "Y",
+                "ts": "111.333",
+            }
+            await router.handle_message(event2)
+
+            # Should have called create_project
+            mock_create.assert_called_once()
+
+        # Should have sent "Creating..." and success messages
+        assert any("Creating project" in msg["text"] for msg in adapter.messages)
+        assert any("I've set up" in msg["text"] for msg in adapter.messages)
+
+        # Pending should be cleaned up
+        assert "C123" not in router._project_creation_handler._pending_projects
+
+    @pytest.mark.asyncio
+    async def test_yes_lowercase_works(self, router_setup):
+        """Test that lowercase 'y' also works."""
+        router, adapter, tmp_path = router_setup
+
+        # Trigger the prompt
+        event1 = {
+            "channel": "C123",
+            "channel_name": "new-idea",
+            "text": "Hello",
+            "ts": "111.222",
+        }
+        await router.handle_message(event1)
+
+        with patch.object(
+            router._project_creation_handler._project_creator, "create_project", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = Project(
+                id="new-idea",
+                channel_name="new-idea",
+                path=tmp_path / "projects" / "new-idea",
+                default_agent_id="claude",
+            )
+
+            event2 = {
+                "channel": "C123",
+                "channel_name": "new-idea",
+                "text": "y",
+                "ts": "111.333",
+            }
+            await router.handle_message(event2)
+
+            mock_create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_yes_full_word_works(self, router_setup):
+        """Test that 'yes' also works."""
+        router, adapter, tmp_path = router_setup
+
+        # Trigger the prompt
+        event1 = {
+            "channel": "C123",
+            "channel_name": "new-idea",
+            "text": "Hello",
+            "ts": "111.222",
+        }
+        await router.handle_message(event1)
+
+        with patch.object(
+            router._project_creation_handler._project_creator, "create_project", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.return_value = Project(
+                id="new-idea",
+                channel_name="new-idea",
+                path=tmp_path / "projects" / "new-idea",
+                default_agent_id="claude",
+            )
+
+            event2 = {
+                "channel": "C123",
+                "channel_name": "new-idea",
+                "text": "yes",
+                "ts": "111.333",
+            }
+            await router.handle_message(event2)
+
+            mock_create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_response_rejects(self, router_setup):
+        """Test that 'N' response sends rejection message."""
+        router, adapter, _ = router_setup
+
+        # Trigger the prompt
+        event1 = {
+            "channel": "C123",
+            "channel_name": "new-idea",
+            "text": "Hello",
+            "ts": "111.222",
+        }
+        await router.handle_message(event1)
+
+        # Send 'N' response
+        event2 = {
+            "channel": "C123",
+            "channel_name": "new-idea",
+            "text": "N",
+            "ts": "111.333",
+        }
+        await router.handle_message(event2)
+
+        # Should have sent rejection message
+        assert any("rename the channel" in msg["text"] for msg in adapter.messages)
+
+        # Pending should be cleaned up
+        assert "C123" not in router._project_creation_handler._pending_projects
+
+    @pytest.mark.asyncio
+    async def test_no_lowercase_works(self, router_setup):
+        """Test that lowercase 'n' also works."""
+        router, adapter, _ = router_setup
+
+        event1 = {
+            "channel": "C123",
+            "channel_name": "new-idea",
+            "text": "Hello",
+            "ts": "111.222",
+        }
+        await router.handle_message(event1)
+
+        event2 = {
+            "channel": "C123",
+            "channel_name": "new-idea",
+            "text": "n",
+            "ts": "111.333",
+        }
+        await router.handle_message(event2)
+
+        assert any("rename the channel" in msg["text"] for msg in adapter.messages)
+        assert "C123" not in router._project_creation_handler._pending_projects
+
+    @pytest.mark.asyncio
+    async def test_invalid_response_reminds_user(self, router_setup):
+        """Test that invalid responses remind user to use Y/N."""
+        router, adapter, _ = router_setup
+
+        # Trigger the prompt
+        event1 = {
+            "channel": "C123",
+            "channel_name": "new-idea",
+            "text": "Hello",
+            "ts": "111.222",
+        }
+        await router.handle_message(event1)
+
+        # Send invalid response
+        event2 = {
+            "channel": "C123",
+            "channel_name": "new-idea",
+            "text": "maybe",
+            "ts": "111.333",
+        }
+        await router.handle_message(event2)
+
+        # Should have sent reminder message
+        assert any("Please reply with **Y**" in msg["text"] for msg in adapter.messages)
+
+        # Pending should still be tracked
+        assert "C123" in router._project_creation_handler._pending_projects
+
+    @pytest.mark.asyncio
+    async def test_creation_failure_sends_error(self, router_setup):
+        """Test that failed project creation sends error message."""
+        router, adapter, _ = router_setup
+
+        # Trigger the prompt
+        event1 = {
+            "channel": "C123",
+            "channel_name": "new-idea",
+            "text": "Hello",
+            "ts": "111.222",
+        }
+        await router.handle_message(event1)
+
+        # Mock creation to fail
+        with patch.object(
+            router._project_creation_handler._project_creator, "create_project", new_callable=AsyncMock
+        ) as mock_create:
+            mock_create.side_effect = Exception("GitHub API error")
+
+            event2 = {
+                "channel": "C123",
+                "channel_name": "new-idea",
+                "text": "Y",
+                "ts": "111.333",
+            }
+            await router.handle_message(event2)
+
+        # Should have sent error message
+        assert any("couldn't create the project" in msg["text"] for msg in adapter.messages)
+
+        # Pending should be cleaned up even on failure
+        assert "C123" not in router._project_creation_handler._pending_projects
+
+
+class TestProjectCreationHandler:
+    """Tests for ProjectCreationHandler directly."""
+
+    def test_pending_project_tracking(self, router_setup):
+        """Test that pending projects are tracked correctly."""
+        router, _, _ = router_setup
+        handler = router._project_creation_handler
+
+        # No pending projects initially
+        assert "C123" not in handler._pending_projects
+
+        # Manually add a pending project
+        handler._pending_projects["C123"] = PendingProjectCreation(
+            channel_id="C123",
+            channel_name="test",
+            thread_ts="111.000",
+            created_at=12345.0,
+        )
+
+        assert "C123" in handler._pending_projects
+        assert "C456" not in handler._pending_projects
+
+    def test_pending_project_fields(self, router_setup):
+        """Test PendingProjectCreation fields."""
+        router, _, _ = router_setup
+        handler = router._project_creation_handler
+
+        handler._pending_projects["C123"] = PendingProjectCreation(
+            channel_id="C123",
+            channel_name="my-project",
+            thread_ts="111.000",
+            created_at=12345.0,
+        )
+
+        pending = handler._pending_projects["C123"]
+        assert pending.channel_id == "C123"
+        assert pending.channel_name == "my-project"
+        assert pending.thread_ts == "111.000"
+        assert pending.created_at == 12345.0


### PR DESCRIPTION
# Background
The current structure of project is set up so that projects must be configured using the CLI before you're able to interact with it from Slack. This makes it impossible to initiate new projects from slack. 

I want to be able to take a project idea, create a repository in github remotely and begin working on the idea.

# Changes
Slack channel name that has yet to map to a configured repository, we will create a remote repository in the user's github account and begin work on a fresh repository.